### PR TITLE
chore: clean up travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: android
 jdk: oraclejdk8
-licenses:
-- android-sdk-preview-license-.+
-- android-sdk-license-.+
-- google-gdk-license-.+
+os: linux
+dist: bionic
 android:
   components:
   - build-tools-28.0.3
   - android-28
+  licenses:
+  - android-sdk-preview-license-.+
+  - android-sdk-license-.+
+  - google-gdk-license-.+
 before_install:
 - openssl aes-256-cbc -K $encrypted_2db283701f8c_key -iv $encrypted_2db283701f8c_iv
   -in secrets.tar.enc -out secrets.tar -d
@@ -34,8 +36,8 @@ jobs:
     - cd android && bundle exec fastlane beta
     deploy:
       provider: releases
-      skip_cleanup: true
-      api_key:
+      cleanup: false
+      token:
         secure: gIxJTtFOm1pJd5gfXuwbN4S8jImYIRQ1HhPb5NhhjGSg2WupsHm45GBBJAUdiUYpw3AOxEDR2FG5IIX+EBxJuuijlByJuxkiPX+EIbaRNIs5Dg8PuDxHN9Q3YgYKRvDM4ZQy99K2h/LLy8Bk7wazYx/JmnqKVLt6VVebfWDNnK0PXce6wyRH1rMc05VtgTku8LhMkryaOaMVX71XWNcwXq7mxO3KmVN0k8IIrZpBPpv01/rV6VuAndbvgxGFQ8AizL3xqGdaf1FG3wjhf1RrAUTrsEY0sEefJW0nEFZR9/NIYR2YyWvyWlYh6MY7XA6kVjUpTOgfR7x6PJpnEoWXij9TB7H7Pc3N40CGUt8uGo8+1qJ1zHH/YSBftEjPC0kT1vS0FTgEhyJ1tpXCyQvJJQOPK0YCU1tdYj+brl6dRxnush4sFTIxQpSSf+aJ8LAlZ5kz1aIiUld+KTeVbJg7Wto0qJEeG8IHHkvtMgzMwdjHQ3N1Go85zT5FQvXrit7ZGg8CAuFQYQcCdgu+k8iRs9XrxLLkMfRAPRJHlgpHLoWfUhaxlze9iXhnxxFBP3ixiNQTkfIJSwaJ69k9CiftwBATNdfodAx4b72MZE0CjGqztW1z0gIJ3/JTNByrhrv1Ld/tOEGQXSQL0SWdePJGZRuxNGD96DzgGoJzx9dVvFY=
       file_glob: true
       file: "$TRAVIS_BUILD_DIR/build/app/outputs/apk/release/*.apk"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: android
-jdk: oraclejdk8
+jdk: openjdk8
 os: linux
-dist: bionic
+dist: xenial
 android:
   components:
   - build-tools-28.0.3


### PR DESCRIPTION
- explicitly add OS
- explicitly add dist
- move licenses under android per [#](https://docs.travis-ci.com/user/languages/android/#dealing-with-licenses)
- rename deploy "api_key" to non-aliased "token"
- update "skip_cleanup" key to non-deprecated "cleanup"