### PR TITLE
fix: update platform names

### DIFF
--- a/lib/core/settings/platform_select.dart
+++ b/lib/core/settings/platform_select.dart
@@ -11,8 +11,8 @@ import '../notifiers/user_settings_notifier.dart';
 import '../services/notifications.dart';
 
 const pc = 'PC';
-const ps4 = 'Sony PlayStation 4';
-const xb1 = 'Microsoft Xbox One';
+const ps4 = 'Sony PlayStation Network';
+const xb1 = 'Microsoft Xbox';
 const swi = 'Nintendo Switch';
 
 const pcColor = Color(0xFFFACA04);


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
xbox and playstation are evolving into multi-console scenarios, so it makes more sense to refer to them by their more generic names instead of the individual product

---

### Reproduction steps
1. Open Settings
2. Tap to hold the Xbox logo
3. See that it shows "Microsoft Xbox One"... but I play on the Xbox Series X!

---

### Evidence/screenshot/link to line

You can see my changes [here](https://github.com/WFCD/navis/compare/master...platforms-modernize?quick_pull=1#diff-35cf136dcd021706cb85b38736153471d71f420c45cf6fcea5160556aedfaec7)

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Maintenance]**
