### PR TITLE
perf: animations and page clean

### DIFF
--- a/lib/codex/views/entry_view.dart
+++ b/lib/codex/views/entry_view.dart
@@ -20,6 +20,7 @@ class EntryViewOpenContainer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return OpenContainer(
+      useRootNavigator: context.rootNavigator.mounted,
       closedColor: Theme.of(context).colorScheme.surface,
       openColor: Theme.of(context).colorScheme.surface,
       openBuilder: (_, __) => EntryView(item: item),

--- a/lib/codex/widgets/codex_entry/entry_info.dart
+++ b/lib/codex/widgets/codex_entry/entry_info.dart
@@ -66,8 +66,7 @@ class BasicItemInfo extends SliverPersistentHeaderDelegate {
               ],
             ),
             if (!disableInfo)
-              Align(
-                alignment: Alignment.bottomCenter,
+              Center(
                 child: _EntryInfoContent(
                   height: expandedHeight,
                   shrinkOffset: shrinkOffset,
@@ -142,6 +141,8 @@ class _EntryInfoContentState extends State<_EntryInfoContent> {
   @override
   Widget build(BuildContext context) {
     const textAlign = TextAlign.center;
+    const curve = Curves.easeOut;
+
     final textTheme = Theme.of(context).textTheme;
     final mediaQuerySize = MediaQuery.of(context).size;
 
@@ -154,9 +155,11 @@ class _EntryInfoContentState extends State<_EntryInfoContent> {
 
     return AnimatedOpacity(
       duration: kThemeAnimationDuration,
+      curve: curve,
       opacity: 1 - (widget.shrinkOffset / widget.height),
       child: AnimatedContainer(
         duration: kThemeAnimationDuration,
+        curve: curve,
         width: animatedContainerWidth,
         height: animatedContainerHeight,
         child: FittedBox(

--- a/lib/home/views/home.dart
+++ b/lib/home/views/home.dart
@@ -3,8 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:navis/l10n/l10n.dart';
 import 'package:navis/router/routes.dart';
-import 'package:navis_ui/navis_ui.dart';
-import 'package:simple_icons/simple_icons.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({
@@ -41,10 +39,10 @@ class HomeView extends StatelessWidget {
       appBar: AppBar(
         toolbarHeight: kTextTabBarHeight,
         actions: [
-          IconButton(
-            onPressed: () => discordInvite.launchLink(context),
-            icon: const AppIcon(SimpleIcons.discord),
-          ),
+          // IconButton(
+          //   onPressed: () => discordInvite.launchLink(context),
+          //   icon: const AppIcon(SimpleIcons.discord),
+          // ),
           IconButton(
             onPressed: () => const SettingsPageRoute().push<void>(context),
             icon: const Icon(Icons.settings_rounded),

--- a/lib/worldstate/widgets/trader_inventory/inventory_tables.dart
+++ b/lib/worldstate/widgets/trader_inventory/inventory_tables.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:navis/worldstate/widgets/trader_inventory/inventory.dart';
+import 'package:navis/worldstate/widgets/trader_inventory/trader_item_card.dart';
 import 'package:navis/worldstate/worldstate.dart';
 import 'package:responsive_builder/responsive_builder.dart';
 import 'package:warframestat_client/warframestat_client.dart';
@@ -53,7 +53,7 @@ class _MobileInventoryDataTable extends StatelessWidget {
     return ListView.builder(
       itemCount: inventory.length,
       itemBuilder: (context, index) {
-        return TraderItemView(traderItem: inventory[index]);
+        return TraderItemCard(item: inventory[index]);
       },
     );
   }

--- a/lib/worldstate/widgets/trader_inventory/trader_item_card.dart
+++ b/lib/worldstate/widgets/trader_inventory/trader_item_card.dart
@@ -67,7 +67,6 @@ class _TrailingColumn extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final format = NumberFormat();
     final textTheme = context.textTheme;
     final headerStyle = textTheme.bodySmall?.copyWith(
       color: context.theme.colorScheme.onSurfaceVariant,
@@ -83,7 +82,7 @@ class _TrailingColumn extends StatelessWidget {
       children: [
         Text(header, style: headerStyle),
         SizedBoxSpacer.spacerHeight6,
-        Text(format.format(value), style: valueStyle),
+        Text(NumberFormat().format(value), style: valueStyle),
       ],
     );
   }

--- a/lib/worldstate/widgets/trader_inventory/trader_item_card.dart
+++ b/lib/worldstate/widgets/trader_inventory/trader_item_card.dart
@@ -4,31 +4,23 @@ import 'package:intl/intl.dart';
 import 'package:navis_ui/navis_ui.dart';
 import 'package:warframestat_client/warframestat_client.dart';
 
-class TraderItemView extends StatelessWidget {
-  const TraderItemView({super.key, required this.traderItem});
+class TraderItemCard extends StatelessWidget {
+  const TraderItemCard({super.key, required this.item});
 
-  final TraderItem traderItem;
+  final TraderItem item;
 
   @override
   Widget build(BuildContext context) {
     return Card(
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 8),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text(
-              traderItem.item,
-              style: context.theme.textTheme.titleMedium,
-            ),
-            Padding(
-              padding: const EdgeInsets.only(top: 8, right: 16),
-              child: _TraderItemTrailing(
-                credits: traderItem.credits ?? 0,
-                ducats: traderItem.ducats ?? 0,
-              ),
-            ),
-          ],
+        child: ListTile(
+          dense: true,
+          title: Text(item.item),
+          trailing: _TraderItemTrailing(
+            credits: item.credits ?? 0,
+            ducats: item.ducats ?? 0,
+          ),
         ),
       ),
     );
@@ -50,6 +42,7 @@ class _TraderItemTrailing extends StatelessWidget {
       height: 65,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
         children: [
           _TrailingColumn(
             header: 'Credits',
@@ -76,10 +69,13 @@ class _TrailingColumn extends StatelessWidget {
   Widget build(BuildContext context) {
     final format = NumberFormat();
     final textTheme = context.textTheme;
-    final headerStyle =
-        textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w500);
-    final valueStyle =
-        textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w800);
+    final headerStyle = textTheme.bodySmall?.copyWith(
+      color: context.theme.colorScheme.onSurfaceVariant,
+    );
+
+    final valueStyle = textTheme.bodyMedium?.copyWith(
+      fontWeight: FontWeight.w800,
+    );
 
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/worldstate/widgets/trader_inventory/trader_item_card.dart
+++ b/lib/worldstate/widgets/trader_inventory/trader_item_card.dart
@@ -45,13 +45,13 @@ class _TraderItemTrailing extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           _TrailingColumn(
-            header: 'Credits',
-            value: credits,
+            header: 'Ducats',
+            value: ducats,
           ),
           const SizedBox(width: 25),
           _TrailingColumn(
-            header: 'Ducats',
-            value: ducats,
+            header: 'Credits',
+            value: credits,
           ),
         ],
       ),


### PR DESCRIPTION
## Description

* The codex page would open as an overlay instead of a page with #548 

* Cleaned up Baro's inventory page for a better eye experience 

* Adjusted the animation for the codex item header  so it's less jarring

* Removed the discord link from the app bar, as a social experiment (can still be found in the app's about dialog)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore