### PR TITLE
fix: miscalculation with weapon rank

### DIFF
--- a/lib/worldstate/widgets/timers/alerts_card.dart
+++ b/lib/worldstate/widgets/timers/alerts_card.dart
@@ -140,7 +140,6 @@ class _AlertReward extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
             )
           : null,
-      isThreeLine: item != null,
       dense: true,
     );
   }

--- a/packages/warframestat_repository/lib/src/utils/mastery_progress.dart
+++ b/packages/warframestat_repository/lib/src/utils/mastery_progress.dart
@@ -13,7 +13,8 @@ class MasteryProgress {
   final int xp;
   final bool missing;
 
-  int get rank => min(sqrt(xp / 1000).floor(), maxRank);
+  int get rank =>
+      min(sqrt(xp / (item.type.isWeapon ? 500 : 1000)).floor(), maxRank);
 
   int get masteryPoints {
     const basePoints = 3000;
@@ -30,13 +31,14 @@ class MasteryProgress {
   }
 
   int get maxRank {
-    const maxRank = 30;
-    const overlevel = maxRank + 10;
+    const max = 30;
 
     final lichWeaponsRegEx = RegExp('Kuva|Tenet|Paracesis');
-    if (lichWeaponsRegEx.hasMatch(item.name)) return overlevel;
-    if (item.productCategory == 'MechSuits') return overlevel;
+    if (lichWeaponsRegEx.hasMatch(item.name) ||
+        item.productCategory == 'MechSuits') {
+      return max + 10;
+    }
 
-    return maxRank;
+    return max;
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

* Fix weapon rank being calculated as a Warframe/Sentinel
* Fix Alerts not rendering  when `ListTile.isThreeline` was set to `true` when and subtitles was not null

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
