### PR TITLE
feat: scroll to top for mastery inventory screen

### DIFF
--- a/lib/home/widgets/mastery_section.dart
+++ b/lib/home/widgets/mastery_section.dart
@@ -55,7 +55,8 @@ class MasteryInProgressContent extends StatelessWidget {
 
           return Column(
             children: [
-              for (final i in state.xpInfo.take(5)) ArsenalItemWidget(item: i),
+              for (final i in state.xpInfo.where((i) => !i.missing).take(5))
+                ArsenalItemWidget(item: i),
             ],
           );
         },

--- a/lib/profile/views/mastery_page.dart
+++ b/lib/profile/views/mastery_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:navis/profile/profile.dart';
 import 'package:navis_ui/navis_ui.dart';
+import 'package:warframestat_repository/warframestat_repository.dart';
 
 class MasteryPage extends StatelessWidget {
   const MasteryPage({super.key});
@@ -13,26 +14,83 @@ class MasteryPage extends StatelessWidget {
   }
 }
 
-class MasteryView extends StatelessWidget {
+class MasteryView extends StatefulWidget {
   const MasteryView({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    const tabs = [
-      Tab(text: 'In Progress'),
-      Tab(text: 'Warframes'),
-      Tab(text: 'Primary'),
-      Tab(text: 'Secondary'),
-      Tab(text: 'Melee'),
-      Tab(text: 'Companions'),
-      Tab(text: 'K-Drive'),
-      Tab(text: 'Archwing'),
-      Tab(text: 'Arch-Gun'),
-      Tab(text: 'Arch-Melee'),
-    ];
+  State<MasteryView> createState() => _MasteryViewState();
+}
 
+class _MasteryViewState extends State<MasteryView> {
+  late final List<ScrollController> _controllers;
+
+  final _tabs = <Map<String, dynamic>>[
+    {
+      'name': 'In Progress',
+      'items': (ArsenalSuccess state) => state.xpInfo
+          .whereNot((i) => i.rank == i.maxRank || i.rank == 0)
+          .toList(),
+    },
+    {
+      'name': 'Warframes',
+      'items': (ArsenalSuccess state) => state.warframes,
+    },
+    {
+      'name': 'Primary',
+      'items': (ArsenalSuccess state) => state.primaries,
+    },
+    {
+      'name': 'Secondary',
+      'items': (ArsenalSuccess state) => state.secondary,
+    },
+    {
+      'name': 'Melee',
+      'items': (ArsenalSuccess state) => state.melee,
+    },
+    {
+      'name': 'Companions',
+      'items': (ArsenalSuccess state) => state.companions,
+    },
+    {
+      'name': 'K-Drive',
+      'items': (ArsenalSuccess state) => state.kDrives,
+    },
+    {
+      'name': 'Archwing',
+      'items': (ArsenalSuccess state) => state.archwing,
+    },
+    {
+      'name': 'Arch-Gun',
+      'items': (ArsenalSuccess state) => state.archGun,
+    },
+    {
+      'name': 'Arch-Melee',
+      'items': (ArsenalSuccess state) => state.archMelee,
+    },
+  ];
+
+  void _onTap(int index) {
+    if (!mounted) return;
+
+    final controller = _controllers[index];
+    if (!controller.hasClients) return;
+    if (controller.position.pixels == 0) return;
+
+    controller.animateTo(0, duration: Durations.short4, curve: Curves.easeIn);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _controllers = _tabs
+        .map((i) => ScrollController(debugLabel: i['name'] as String))
+        .toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return DefaultTabController(
-      length: tabs.length,
+      length: _tabs.length,
       child: NestedScrollView(
         floatHeaderSlivers: true,
         headerSliverBuilder: (context, innerBoxIsScrolled) {
@@ -47,7 +105,12 @@ class MasteryView extends StatelessWidget {
                 title: MasteryItemSearchBar(
                   onPressed: () => Navigator.pop(context),
                 ),
-                bottom: const TabBar(isScrollable: true, tabs: tabs),
+                bottom: TabBar(
+                  isScrollable: true,
+                  tabs:
+                      _tabs.map((i) => Tab(text: i['name'] as String)).toList(),
+                  onTap: _onTap,
+                ),
               ),
             ),
           ];
@@ -59,26 +122,35 @@ class MasteryView extends StatelessWidget {
             }
 
             return TabBarView(
-              children: [
-                ArsenalItems(
-                  items: state.xpInfo
-                      .whereNot((i) => i.rank == i.maxRank || i.rank == 0)
-                      .toList(),
-                ),
-                ArsenalItems(items: state.warframes),
-                ArsenalItems(items: state.primaries),
-                ArsenalItems(items: state.secondary),
-                ArsenalItems(items: state.melee),
-                ArsenalItems(items: state.companions),
-                ArsenalItems(items: state.kDrives),
-                ArsenalItems(items: state.archwing),
-                ArsenalItems(items: state.archGun),
-                ArsenalItems(items: state.archMelee),
-              ],
+              children: _tabs
+                  .asMap()
+                  .map(
+                    (index, tab) {
+                      return MapEntry(
+                        index,
+                        ArsenalItems(
+                          controller: _controllers[index],
+                          items: (tab['items'] as List<MasteryProgress>
+                              Function(ArsenalSuccess))(state),
+                        ),
+                      );
+                    },
+                  )
+                  .values
+                  .toList(),
             );
           },
         ),
       ),
     );
+  }
+
+  @override
+  void dispose() {
+    for (final controller in _controllers) {
+      controller.dispose();
+    }
+
+    super.dispose();
   }
 }

--- a/lib/profile/widgets/arsenal_items.dart
+++ b/lib/profile/widgets/arsenal_items.dart
@@ -6,8 +6,9 @@ import 'package:navis/settings/settings.dart';
 import 'package:warframestat_repository/warframestat_repository.dart';
 
 class ArsenalItems extends StatelessWidget {
-  const ArsenalItems({super.key, required this.items});
+  const ArsenalItems({super.key, this.controller, required this.items});
 
+  final ScrollController? controller;
   final List<MasteryProgress> items;
 
   @override
@@ -24,6 +25,7 @@ class ArsenalItems extends StatelessWidget {
         await BlocProvider.of<ArsenalCubit>(context).syncXpInfo(username);
       },
       child: ListView.builder(
+        controller: controller,
         itemCount: items.length,
         itemBuilder: (context, index) => ArsenalItemWidget(item: items[index]),
       ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

* Allow users to scroll back to the top by pressing on the current tab while in Mastery inventory screen
* Adjust Mastery inventory order to push missing items to the top instead of in progress items

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
